### PR TITLE
Wrap lines, comment out other parts for setup>verify, exception handling, other fixes.

### DIFF
--- a/kitchen-sync/android/README.md
+++ b/kitchen-sync/android/README.md
@@ -116,7 +116,7 @@ and add data persistence along with offline support!
     `MainActivity` you will find the `createListItem` method. Replace the last line, "return null;"
     with the following:
  ```java
- 	    Document document = database.createDocument();
+        Document document = database.getDocument(id); // creates a document with the given id
 
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put("_id", id);
@@ -127,6 +127,8 @@ and add data persistence along with offline support!
 
          return document;
  ```
+
+    That `putProperties()` method is the one that actually creates the document in Couchbase Lite.
 
  8. Next, we start our `LiveQuery`. Like a regular `Query`, it gives us the ability to filter and
     order the index we created in step 3. However, it also can send us results that appear
@@ -173,7 +175,7 @@ and add data persistence along with offline support!
 
         initItemListAdapter();
 
-	startLiveQuery();        
+        startLiveQuery();
 
         ...
 ```

--- a/kitchen-sync/android/app/build.gradle
+++ b/kitchen-sync/android/app/build.gradle
@@ -29,7 +29,7 @@ android {
 
 dependencies {
     compile 'com.android.support:support-v4:19.0.+'
-    compile 'com.couchbase.lite:couchbase-lite-android:1.0.3'
+    compile 'com.couchbase.lite:couchbase-lite-android:1.0.4'
 }
 
 def platform = "mac"


### PR DESCRIPTION
Some of those lines were super long and thus hard to read in the IDE.  Lines wrap (where possible) at the android studio default.